### PR TITLE
switch build status to svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cluster-proportional-vertical-autoscaler (BETA)
 
-[![Build Status](https://travis-ci.org/kubernetes-incubator/cluster-proportional-vertical-autoscaler.png)](https://travis-ci.org/kubernetes-incubator/cluster-proportional-vertical-autoscaler)
+[![Build Status](https://travis-ci.org/kubernetes-incubator/cluster-proportional-vertical-autoscaler.svg)](https://travis-ci.org/kubernetes-incubator/cluster-proportional-vertical-autoscaler)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler)](https://goreportcard.com/report/github.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler)
 
 ## Overview


### PR DESCRIPTION
This is _**incredibly**_ minor so please feel free to ignore but,
I was taking a look at this project and noticed the build status text was pretty blurry on my laptop:
<img width="978" alt="screen shot 2018-09-18 at 8 49 31 pm" src="https://user-images.githubusercontent.com/917931/45730028-60dd6780-bb84-11e8-825e-f4e3d473e6c7.png">


versus with SVG:
<img width="978" alt="screen shot 2018-09-18 at 8 48 47 pm" src="https://user-images.githubusercontent.com/917931/45730010-44d9c600-bb84-11e8-86b2-20733807735d.png">

/shrug
