### PR TITLE
Fix typo in OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,5 +4,5 @@
 approvers:
   - thockin
   - dnardo
-  - zihongz
+  - MrHohn
   - bowei


### PR DESCRIPTION
Seems like we have a typo in the OWNERS file :/
/assign @thockin 