### PR TITLE
Update example template to use latest release

### DIFF
--- a/examples/cpvpa-nginx-example-with-configmap.yaml
+++ b/examples/cpvpa-nginx-example-with-configmap.yaml
@@ -67,7 +67,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cpvpa-amd64:v0.6.0
+        - image: gcr.io/google_containers/cpvpa-amd64:{LATEST_RELEASE}
           name: autoscaler
           command:
             - /cpvpa

--- a/examples/cpvpa-nginx-example.yaml
+++ b/examples/cpvpa-nginx-example.yaml
@@ -47,7 +47,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: gcr.io/google_containers/cpvpa-amd64:v0.6.0
+        - image: gcr.io/google_containers/cpvpa-amd64:{LATEST_RELEASE}
           name: autoscaler
           command:
             - /cpvpa


### PR DESCRIPTION
Replacing the hardcoded version tag so we won't need to update it every time we bump the version.