### PR TITLE
Push image to staging registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BIN := cpvpa
 PKG := github.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler
 
 # Where to push the docker image.
-REGISTRY ?= gcr.io/google_containers
+REGISTRY ?= staging-k8s.gcr.io
 
 # Which architecture to build - see $(ALL_ARCH) for options.
 ARCH ?= amd64


### PR DESCRIPTION
Stop pushing to `gcr.io/google_containers` and use staging instead.
/assign @bowei 

(cc @lzang One more change before we can cut a new release.)