### PR TITLE
Remove -ti in docker build to allow automation run the build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ build: bin/$(ARCH)/$(BIN)
 bin/$(ARCH)/$(BIN): build-dirs
 	@echo "building: $@"
 	@docker run                                                            \
-	    -ti                                                                \
 	    --rm                                                               \
 	    -u $$(id -u):$$(id -g)                                             \
 	    -v $$(pwd)/.go:/go                                                 \
@@ -115,7 +114,6 @@ version:
 
 test: build-dirs
 	@docker run                                                            \
-	    -ti                                                                \
 	    --rm                                                               \
 	    -u $$(id -u):$$(id -g)                                             \
 	    -v $$(pwd)/.go:/go                                                 \


### PR DESCRIPTION
Remove -ti in docker build to allow automation run the build.