### PR TITLE
Prevent target kind to be an unsupported one

### DIFF
--- a/pkg/autoscaler/k8sclient/k8sclient.go
+++ b/pkg/autoscaler/k8sclient/k8sclient.go
@@ -140,8 +140,7 @@ func discoverAPI(client kubernetes.Interface, kindArg string) (kind string, grou
 	groupVersions = map[string]bool{}
 	for _, resourceList := range resourceLists {
 		for _, res := range resourceList.APIResources {
-			if res.Name == plural {
-				kind = res.Kind
+			if res.Name == plural && res.Kind == kind {
 				groupVersions[resourceList.GroupVersion] = true
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Prevent target kind to be an unsupported one

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #31 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
An issue causing cpva to fail starting when there are multiple API resources with duplicating names but different kinds is now fixed.
```

