### PR TITLE
Update staging gcr registry to the new one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BIN := cpvpa
 PKG := github.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler
 
 # Where to push the docker image.
-REGISTRY ?= staging-k8s.gcr.io
+REGISTRY ?= gcr.io/k8s-staging-cpa
 
 # Which architecture to build - see $(ALL_ARCH) for options.
 ARCH ?= amd64


### PR DESCRIPTION
Updating the registry to the new one added by kubernetes/k8s.io#725.

This is to unblock https://github.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler/issues/33.